### PR TITLE
Fix BCD exception

### DIFF
--- a/src/hicdex/utils.py
+++ b/src/hicdex/utils.py
@@ -37,4 +37,4 @@ async def http_request(session: aiohttp.ClientSession, method: str, **kwargs):
         headers=headers,
         **kwargs,
     ) as response:
-        return await response.json()
+        return await response.json(content_type=None)


### PR DESCRIPTION
Don't check the content type when parsing what we expect to be json response, to prevent crash when BCD return wrong content type.